### PR TITLE
New "ctags append" config feature

### DIFF
--- a/sourcecodebrowser/data/configure_dialog.ui
+++ b/sourcecodebrowser/data/configure_dialog.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.16.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="configure_dialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -20,10 +21,10 @@
             <child>
               <object class="GtkButton" id="button1">
                 <property name="label">gtk-close</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -48,10 +49,10 @@
             <child>
               <object class="GtkCheckButton" id="show_line_numbers">
                 <property name="label" translatable="yes">Show _line numbers in tree</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -67,10 +68,10 @@
             <child>
               <object class="GtkCheckButton" id="load_remote_files">
                 <property name="label" translatable="yes">Load symbols from _remote files</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -86,10 +87,10 @@
             <child>
               <object class="GtkCheckButton" id="expand_rows">
                 <property name="label" translatable="yes">Start with rows _expanded</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -105,10 +106,10 @@
             <child>
               <object class="GtkCheckButton" id="sort_list">
                 <property name="label" translatable="yes">_Sort list alphabetically</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -144,7 +145,6 @@
                     <property name="can_focus">True</property>
                     <property name="invisible_char">●</property>
                     <property name="text" translatable="yes">ctags</property>
-                    <property name="invisible_char_set">True</property>
                     <signal name="changed" handler="on_ctags_executable_changed" swapped="no"/>
                   </object>
                   <packing>
@@ -160,6 +160,45 @@
                 <property name="fill">True</property>
                 <property name="padding">6</property>
                 <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">ctags append str</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="ctags_append">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <signal name="changed" handler="on_ctags_append_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">6</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">6</property>
+                <property name="position">5</property>
               </packing>
             </child>
           </object>

--- a/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
+++ b/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
@@ -26,6 +26,10 @@
       <summary>Ctags Executable</summary>
       <description>Specifies the executable path for Exuberant Ctags.</description>
     </key>
+    <key type="s" name="ctags-append">
+      <default>''</default>
+      <summary>Ctags Append</summary>
+      <description>Specifies any command line modifiers to apply to Ctags when run by the parser.</description>
+    </key>
   </schema>
 </schemalist>
-


### PR DESCRIPTION
I put this together because it was useful for myself, since I have some javascript files with a custom file extension. I wanted these files to be recognized with ctags as javascript, so I put this together so I could type in "--langmap=javascript:.itz.js.node" but with the UI changes and what not, this is configurable so ctags could be appended with anything.

Maybe others could find it useful as well.